### PR TITLE
feat(app): add verified filter in stake pool list

### DIFF
--- a/packages/app-mining/src/components/StakePoolTableV2/index.tsx
+++ b/packages/app-mining/src/components/StakePoolTableV2/index.tsx
@@ -81,6 +81,7 @@ const StakePoolTableV2: FC<{
   const [aprFilter, setAprFilter] = useState(false)
   const [commissionFilter, setCommissionFilter] = useState(kind === 'delegate')
   const [remainingFilter, setRemainingFilter] = useState(kind === 'delegate')
+  const [verifiedFilter, setVerifiedFilter] = useState(false)
   const [remainingValue, setRemainingValue] = useAtom(remainingValueAtom)
 
   const [stakePoolModalKey, setStakePoolModalKey] =
@@ -139,6 +140,13 @@ const StakePoolTableV2: FC<{
               {remainingStake: {gt: remainingValue}},
               {remainingStake: {equals: null}},
             ],
+          },
+          verifiedFilter && {
+            accounts: {
+              is: {
+                identityVerified: {equals: true},
+              },
+            },
           },
         ].filter(isTruthy),
       },
@@ -246,6 +254,14 @@ const StakePoolTableV2: FC<{
             }
           >
             {'Commission < 100%'}
+          </Checkbox>
+          <Checkbox
+            checked={verifiedFilter}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setVerifiedFilter(e.target.checked)
+            }
+          >
+            {'Verified'}
           </Checkbox>
           <Block display="flex" alignItems="center">
             <Checkbox


### PR DESCRIPTION
# **Changelog**
- Adds a filter to allow individuals to sort by verified pools:
![Preview](https://i.imgur.com/Nf86LhI.png)

# Explanation for proposed changes

There has been a variety of stake pools which have been gradually popping up, especially from large-scale providers, with sub 10k in Phala staked and an APR > 200% due to the fashion in which they abuse the low delegated amount with the high income-amount gained at first when bootstrapping a stake pool with a new node. To provide henceforth a better perspective on what are some 'safe' nodes to partake in (as of right now no "bad behaviour" or "early bird" filter exists), I propose to add a filter (disabled by default) which would display exclusively verified nodes.

Some changes to be expected from adding this:

- Increase in demand for verifications
- Decrease in temp stake pools
- More long-term staking on pools